### PR TITLE
fix unresolved external symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ Based on the information above, there are several optimizations and changes made
 
   https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new?ncid=em-prod-816193
 
+## vcpkg install ffmpeg
+
+* Windows
+```
+./vcpkg install ffmpeg[core,avcodec,avformat,nvcodec,amf,qsv]:x64-windows-static
+```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Based on the information above, there are several optimizations and changes made
 
 * intel
 
-  Windows Intel(r) graphics driver since 27.20.100.8935 version. 
+  Windows Intel(r) graphics driver since 27.20.100.8935 version.
 
   [Hardware Platforms Supported by the Intel(R) Media SDK GPU Runtime](https://www.intel.com/content/www/us/en/docs/onevpl/upgrade-from-msdk/2023-1/onevpl-hardware-support-details.html#HARDWARE-PLATFORMS-SUPPORTED-BY-THE-INTEL-R-MEDIA-SDK-GPU-RUNTIME)
 
@@ -82,4 +82,10 @@ Based on the information above, there are several optimizations and changes made
 * Windows
 ```
 ./vcpkg install ffmpeg[core,avcodec,avformat,nvcodec,amf,qsv]:x64-windows-static
+```
+
+* Mac
+```
+./vcpkg install ffmpeg[core,avcodec,avformat]:x64-osx
+./vcpkg install ffmpeg[core,avcodec,avformat]:arm64-osx
 ```

--- a/build.rs
+++ b/build.rs
@@ -193,6 +193,15 @@ mod ffmpeg {
             .map(|lib| println!("cargo:rustc-link-lib={}", lib))
             .count();
 
+        // error LNK2001: unresolved external symbol IID_ICodecAPI
+        // error LNK2001: unresolved external symbol IID_IMFMediaEventGenerator
+        // error LNK2001: unresolved external symbol IID_IMFTransform
+        #[cfg(target_os = "windows")]
+        [
+            "Mfuuid", "Strmiids"
+        ]
+        .map(|lib| println!("cargo:rustc-link-lib={}", lib));
+
         if target_os == "macos" || target_os == "ios" {
             println!("cargo:rustc-link-lib=framework=CoreFoundation");
             println!("cargo:rustc-link-lib=framework=CoreVideo");

--- a/build.rs
+++ b/build.rs
@@ -143,7 +143,11 @@ mod ffmpeg {
             target = target.replace("x64", "x86");
         }
         println!("cargo:info={}", target);
-        path.push("installed");
+        if let Ok(vcpkg_root) = std::env::var("VCPKG_INSTALLED_ROOT") {
+            path = vcpkg_root.into();
+        } else {
+            path.push("installed");
+        }
         path.push(target);
 
         println!(
@@ -176,7 +180,7 @@ mod ffmpeg {
         let dyn_libs: Vec<&str> = if target_os == "windows" {
             ["User32", "bcrypt", "ole32", "advapi32"].to_vec()
         } else if target_os == "linux" {
-            let mut v = ["va", "va-drm", "drm", "va-x11", "vdpau", "X11", "stdc++"].to_vec();
+            let mut v = ["va", "va-drm", "va-x11", "vdpau", "X11", "stdc++"].to_vec();
             if target_arch == "x86_64" {
                 v.push("z");
             }

--- a/build.rs
+++ b/build.rs
@@ -208,6 +208,7 @@ mod ffmpeg {
             println!("cargo:rustc-link-lib=framework=CoreMedia");
             println!("cargo:rustc-link-lib=framework=VideoToolbox");
             println!("cargo:rustc-link-lib=framework=AVFoundation");
+            println!("cargo:rustc-link-lib=framework=AudioToolbox");
         }
     }
 


### PR DESCRIPTION
使用 vcpkg 安装 ffmpeg 静态链接库后运行
```
cargo run --example available
```
报一下错误
```
= note: LINK : warning LNK4098: 默认库“LIBCMT”与其他库的使用冲突；请使用 /NODEFAULTLIB:library
          libhwcodec-459102ab20533d1c.rlib(mfenc.o) : error LNK2001: 无法解析的外部符号 IID_ICodecAPI
          libhwcodec-459102ab20533d1c.rlib(mfenc.o) : error LNK2001: 无法解析的外部符号 IID_IMFMediaEventGenerator
          libhwcodec-459102ab20533d1c.rlib(mf_utils.o) : error LNK2001: 无法解析的外部符号 IID_IMFTransform
```